### PR TITLE
Add subject and body template to mailto link

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
 	<section id="kommunikation">
 		<h2>Kommunikation</h2>
 		<p>
-			Neben E-Mail über <a href="mailto:0xA@flipdot.org">0xA@flipdot.org</a> sind wir meist auch spontan im IRC in
+			Neben E-Mail über <a href="mailto:0xA@flipdot.org?subject=Anmeldung Hackumenta&body=Werte Lebensformen,%0D%0A%0D%0A">0xA@flipdot.org</a> sind wir meist auch spontan im IRC in
 			<a href="irc://chat.freenode.net:7070/flipdot">#flipdot auf freenode</a> und weniger spontan <a
 				href="https://twitter.com/flipdot_ks">über Twitter</a> erreichbar.
 		</p>


### PR DESCRIPTION
This makes it much easier for people to register, since they don't have to think much anymore about the subject or address (as suggested by @dargmuesli).